### PR TITLE
Update pyyaml require range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,5 @@ setup(name='aconfig',
       packages=['pyconfig'],
       zip_safe=False,
       install_requires=[
-          "pyyaml>=3.0, <4.0"
+          "pyyaml>=3.0, <6.0"
           ])


### PR DESCRIPTION
PyYaml at 5.3.1 still hasn't broken the api this package requires. Updating it so it will install correctly with package managers.